### PR TITLE
Windows support to call multiple workflows in queue_prompt.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -221,7 +221,7 @@ runs:
         key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles(format('{0}', inputs.conda_env_file)) }}
 
     - name: '[Win] Setup Conda'
-      uses: conda-incubator/setup-miniconda@v3.0.3
+      uses: conda-incubator/setup-miniconda@v3
       if: ${{ inputs.os == 'windows' }}
       with:
         activate-environment: comfyui

--- a/action.yml
+++ b/action.yml
@@ -225,7 +225,7 @@ runs:
         conda list
       shell: powershell
 
-    - name: Generate hash from models-json
+    - name: '[Win] Generate hash from models-json'
       if: ${{ inputs.os == 'windows' }}
       id: generate_hash_windows
       run: |

--- a/action.yml
+++ b/action.yml
@@ -237,27 +237,35 @@ runs:
       shell: powershell
 
     - name: Generate hash from models-json
+      if: ${{ inputs.os == 'windows' }}
       id: generate_hash_windows
       run: |
         $hash = (Get-FileHash -Algorithm SHA256 -InputStream ([System.IO.MemoryStream][System.Text.Encoding]::UTF8.GetBytes("${{ inputs.models-json }}"))).Hash
-        echo "::set-output name=hash::$hash"
+        echo "hash=$hash" >> $GITHUB_OUTPUT
       shell: powershell
-  
+
+    - name: '[Windows] Cache models'
+      if: ${{ inputs.os == 'windows' }}
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/models
+        key: ${{ runner.os }}-models-${{ steps.generate_hash_windows.outputs.hash }}
 
     # Keep in mind the self runner must be setup with a model in C:\actions-runner\
-    - name: '[Win] Download models'
-      if: ${{ inputs.os == 'windows' }}
-      run: |
-        cd $Env:GITHUB_ACTION_PATH
-        ls "$Env:GITHUB_WORKSPACE"
-        cp "C:\actions-runner\v1-5-pruned-emaonly.ckpt" "$Env:GITHUB_WORKSPACE/models/checkpoints"
-      shell: powershell
+    # - name: '[Win] Download models'
+    #   if: ${{ inputs.os == 'windows' }}
+    #   run: |
+    #     cd $Env:GITHUB_ACTION_PATH
+    #     ls "$Env:GITHUB_WORKSPACE"
+    #     cp "C:\actions-runner\v1-5-pruned-emaonly.ckpt" "$Env:GITHUB_WORKSPACE/models/checkpoints"
+    #   shell: powershell
 
-    - name: '[Win] Run Python application quick test'
+    - name: '[Windows] Download models'
       if: ${{ inputs.os == 'windows' }}
       shell: powershell
       run: |
-        python $Env:GITHUB_WORKSPACE/main.py --quick-test-for-ci
+        Set-Location ${{ env.GITHUB_ACTION_PATH }}
+        python download-models.py raw "${{ inputs.models-json }}" "${{ env.GITHUB_WORKSPACE }}\models\"
 
     - name: '[Win] Run Python application'
       if: ${{ inputs.os == 'windows' }}
@@ -276,76 +284,6 @@ runs:
         python poll_server_start.py
       shell: powershell
 
-    - name: '[Win] Queue Prompt'
-      id: win_queue_prompt
-      if: ${{ inputs.os == 'windows' }}
-      shell: powershell
-      run: |
-        cd $Env:GITHUB_ACTION_PATH
-        $FULL_PATH="${Env:GITHUB_WORKSPACE}/${{ inputs.workflow_json_path }}"
-        Write-Output "Full path to the JSON file: $FULL_PATH"
-        $PROMPT_ID = python queue_prompt.py "$FULL_PATH"
-        Write-Output "prompt_id=$PROMPT_ID" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-        Write-Output "Script output: "
-        Write-Output "$PROMPT_ID"
-
-    - name: '[Win] Get start time'
-      id: win_start_time
-      if: ${{ inputs.os == 'windows' }}
-      run: |
-        $currentTime = [int][double]::Parse((Get-Date -UFormat "%s"))
-        Write-Output "start_time=$currentTime" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-        Write-Output "Start time: "
-        Write-Output "$currentTime"
-      shell: powershell
-
-    - name: '[Win] Check Prompt Status and Get Output Files'
-      if: ${{ inputs.os == 'windows' }}
-      shell: powershell
-      run: |
-        cd $Env:GITHUB_ACTION_PATH
-        Write-Output "Prompt ID: ${{ steps.win_queue_prompt.outputs.prompt_id }}"
-        python check_prompt_status.py ${{ steps.win_queue_prompt.outputs.prompt_id }} http://localhost:8188/history ${{ inputs.timeout }}
-
-    - name: '[Win] Get end time'
-      id: win_end_tim
-      if: ${{ inputs.os == 'windows' }}
-      run: |
-        $currentTime = [int][double]::Parse((Get-Date -UFormat "%s"))
-        Write-Output "end_time=$currentTime" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-        Write-Output "End time: "
-        Write-Output "$currentTime"
-      shell: powershell
-
-    - name: '[Win] Auth to GCS'
-      uses: "google-github-actions/auth@v2"
-      if: ${{ inputs.os == 'windows' }}
-      with:
-        credentials_json: "${{ inputs.google_credentials }}"
-
-    - name: '[Win] Upload Output Files to GCS'
-      if: ${{ success() && inputs.os == 'windows'}}
-      id: win_upload-output-files
-      uses: google-github-actions/upload-cloud-storage@v2
-      with:
-        path: ${{ github.workspace }}/output
-        destination: ${{ inputs.gcs_bucket_name }}/output-files/${{ github.job }}-${{ inputs.os }}-${{ inputs.workflow_name }}-run${{ github.run_id }}
-        glob: "${{ inputs.output_prefix }}*"
-
-    - name: '[Win] Upload log file to GCS'
-      if: ${{ ( success() || failure() ) && inputs.os == 'windows'}}
-      id: win_upload-log-files
-      uses: google-github-actions/upload-cloud-storage@v2
-      with:
-        path: ${{ github.workspace }}/application.log
-        destination: ${{ inputs.gcs_bucket_name }}/logs/${{ github.job }}-${{ inputs.os }}-${{ inputs.workflow_name }}-run${{ github.run_id }}
-
-    - name: '[Win] Debug print out commit timestamp and commit message'
-      if: ${{ inputs.os == 'windows' }}
-      shell: powershell
-      run: |
-        Write-Output "Event : ${{ github.event }}"
-
     - name: '[Win] Get Commit Details'
       id: win_get_commit_details
       if: ${{ inputs.os == 'windows' }}
@@ -354,40 +292,31 @@ runs:
         $timestamp = git show -s --format=%cI HEAD^
         $message = git show -s --format=%s HEAD^
         $commit_hash = git rev-parse HEAD^
-        Write-Output "Commit time: $timestamp"
-        Write-Output "Commit title: $message"
-        Write-Output "Commit hash: $commit_hash"
-        Write-Output "commit_time=$timestamp" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-        Write-Output "commit_title=$message" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-        Write-Output "commit_hash=$commit_hash" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+        "commit_time=$timestamp" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+        "commit_title=$message" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+        "commit_hash=$commit_hash" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
 
-    - name: '[Win] Call API to upload artifact details'
-      if: ${{ inputs.os == 'windows' && success() }}
+    - name: '[Windows] Queue Prompts'
+      id: windows_queue_prompt
+      if: ${{ inputs.os == 'windows' }}
       shell: powershell
       run: |
-        $response = Invoke-WebRequest -Uri "${{ inputs.api_endpoint}}" `
-          -Method POST `
-          -Headers @{"Content-Type"="application/json"} `
-          -Body (@{
-            "repo" = "${{ github.repository }}"
-            "run_id" = "${{ github.run_id }}"
-            "os" = "${{ inputs.os }}"
-            "cuda_version" = "${{ inputs.cuda_version }}"
-            "output_files_gcs_paths" = "${{ steps.win_upload-output-files.outputs.uploaded }}"
-            "commit_hash" = "${{ steps.win_get_commit_details.outputs.commit_hash }}"
-            "commit_time" = "${{ steps.win_get_commit_details.outputs.commit_time }}"
-            "commit_message" = "${{ steps.win_get_commit_details.outputs.commit_title }}"
-            "branch_name" = "${{ github.ref_name }}"
-            "bucket_name" = "${{ inputs.gcs_bucket_name }}"
-            "workflow_name" = "${{ inputs.workflow_name }}"
-            "start_time" = ${{ steps.win_start_time.outputs.start_time }}
-            "end_time" = ${{ steps.win_end_time.outputs.end_time }}
-          } | ConvertTo-Json)
-
-        if ($response.StatusCode -ne 200) {
-            Write-Error "API request failed with status code $($response.StatusCode)"
-            exit 1
-        }
+        Set-Location ${{ env.GITHUB_ACTION_PATH }}
+        Write-Host "Running workflows: ${{ inputs.workflow_filenames }}"
+        python queue_prompt.py `
+          --comfy-workflow-names "${{ inputs.workflow_filenames }}" `
+          --github-action-workflow-name "${{ github.workflow }}" `
+          --os "${{ inputs.os }}" `
+          --run-id "${{ github.run_id }}" `
+          --gsc-bucket-name "${{ inputs.gcs_bucket_name }}" `
+          --workspace-path "${{ github.workspace }}" `
+          --output-file-prefix "${{ inputs.output_prefix }}" `
+          --repo "${{ github.repository }}" `
+          --commit-hash "${{ steps.win_get_commit_details.outputs.commit_hash }}" `
+          --commit-time "${{ steps.win_get_commit_details.outputs.commit_time }}" `
+          --commit-message "${{ steps.win_get_commit_details.outputs.commit_title }}" `
+          --branch-name "${{ github.ref_name }}" `
+          --api-endpoint "${{ inputs.api_endpoint }}"
 
     - name: '[Win] Upload Output Files'
       uses: actions/upload-artifact@v4
@@ -402,8 +331,3 @@ runs:
       with:
         name: app-logs-${{ github.job }}-${{ inputs.os }}-${{inputs.workflow_name}}-${{ github.run_id }}
         path: ${{ github.workspace }}/application.log
-
-    - name: '[Win] Cleanup output files only'
-      if: ${{ inputs.os == 'windows' && ( success() || failure() ) }}
-      shell: powershell
-      run: Remove-Item -Path "${{ github.workspace }}/output/*" -Recurse -Force

--- a/action.yml
+++ b/action.yml
@@ -262,7 +262,7 @@ runs:
         Set-Location $Env:GITHUB_ACTION_PATH
         ls
         conda activate comfyui
-        python download-models.py raw "${{ inputs.models-json }}" "${{ env.GITHUB_WORKSPACE }}\models\"
+        python download-models.py raw "${{ inputs.models-json }}" "$Env:GITHUB_WORKSPACE\models\"
 
     - name: '[Win] Run Python application'
       if: ${{ inputs.os == 'windows' }}

--- a/action.yml
+++ b/action.yml
@@ -210,26 +210,11 @@ runs:
     ##                                                                                 ##
     #####################################################################################
 
-    - name: '[Windows] Cache Conda'
-      if: ${{ inputs.os != 'windows' }}
-      uses: actions/cache@v4
-      env:
-          # Increase this value to reset cache if the environment file has not changed
-          CACHE_NUMBER: 0
-      with:
-        path: C:\Miniconda3\envs\comfyui
-        key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles(format('{0}', inputs.conda_env_file)) }}
-
-    - name: '[Win] Setup Conda'
-      uses: conda-incubator/setup-miniconda@v3
+    - name: '[Win-Only] Install Pytorch'
       if: ${{ inputs.os == 'windows' }}
-      with:
-        auto-update-conda: false
-        activate-environment: comfyui
-        auto-activate-base: false
-        environment-file: ${{ inputs.conda_env_file }}
-        use-only-tar-bz2: true
-      continue-on-error: true
+      shell: powershell
+      run: |
+        conda env create -f ${{ inputs.conda_env_file }}
 
     - name: "[Win] Check conda environment"
       if: ${{ inputs.os == 'windows' }}

--- a/action.yml
+++ b/action.yml
@@ -227,7 +227,7 @@ runs:
         activate-environment: comfyui
         auto-activate-base: false
         auto-update-conda: true
-        miniconda-version: "Miniconda3-py312_24.4.0-0-Windows-x86_64.exe"
+        miniconda-version: "Miniconda3-py312_24.4.0-0"
         environment-file: ${{ inputs.conda_env_file }}
         use-only-tar-bz2: true
 

--- a/action.yml
+++ b/action.yml
@@ -262,7 +262,10 @@ runs:
         Set-Location $Env:GITHUB_ACTION_PATH
         ls
         conda activate comfyui
-        python download-models.py raw "${{ inputs.models-json }}" "$Env:GITHUB_WORKSPACE\models\"
+        $jsonInput = '${{ inputs.models-json }}'
+        $outputDir = "$Env:GITHUB_WORKSPACE\models\"
+        Write-Host "Running download-models.py with input: $jsonInput and output directory: $outputDir"
+        python download-models.py raw "$jsonInput" "$outputDir"
 
     - name: '[Win] Run Python application'
       if: ${{ inputs.os == 'windows' }}

--- a/action.yml
+++ b/action.yml
@@ -243,7 +243,10 @@ runs:
       if: ${{ inputs.os == 'windows' }}
       id: generate_hash_windows
       run: |
-        $hash = (Get-FileHash -Algorithm SHA256 -InputStream ([System.IO.MemoryStream][System.Text.Encoding]::UTF8.GetBytes("${{ inputs.models-json }}"))).Hash
+        $jsonString = '{"v1-5-pruned-emaonly.ckpt": {"url": "https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.ckpt", "directory": "checkpoints"}}'
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($jsonString)
+        $stream = [System.IO.MemoryStream]::new($bytes)
+        $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stream).Hash
         echo "hash=$hash" >> $GITHUB_OUTPUT
       shell: powershell
 

--- a/action.yml
+++ b/action.yml
@@ -259,7 +259,7 @@ runs:
       if: ${{ inputs.os == 'windows' }}
       shell: powershell
       run: |
-        Set-Location ${{ env.GITHUB_ACTION_PATH }}
+        Set-Location $Env:GITHUB_ACTION_PATH
         ls
         conda activate comfyui
         python download-models.py raw "${{ inputs.models-json }}" "${{ env.GITHUB_WORKSPACE }}\models\"

--- a/action.yml
+++ b/action.yml
@@ -231,8 +231,10 @@ runs:
         Set-Location $Env:GITHUB_ACTION_PATH
         conda activate comfyui
         ls
+        Write-Host "Running hash_string.py..."
         python hash_string.py '${{ inputs.models-json }}' > hash_output.txt
         $hash = Get-Content hash_output.txt
+        Write-Host "Hash value: $hash"
         echo "hash=$hash" >> $Env:GITHUB_ENV
       shell: powershell
 

--- a/action.yml
+++ b/action.yml
@@ -227,7 +227,7 @@ runs:
         activate-environment: comfyui
         auto-activate-base: false
         auto-update-conda: true
-        miniconda-version: "Miniconda3-py312_24.4.0-0"
+        miniconda-version: "py312_24.4.0-0"
         environment-file: ${{ inputs.conda_env_file }}
         use-only-tar-bz2: true
 

--- a/action.yml
+++ b/action.yml
@@ -215,7 +215,6 @@ runs:
       shell: powershell
       run: |
         conda env create -f ${{ inputs.conda_env_file }}
-        conda activate comfyui
 
     - name: "[Win] Check conda environment"
       if: ${{ inputs.os == 'windows' }}
@@ -228,6 +227,7 @@ runs:
       if: ${{ inputs.os == 'windows' }}
       id: generate_hash_windows
       run: |
+        conda activate comfyui
         Set-Location ${{ env.GITHUB_ACTION_PATH }}
         $hash = python3 hash_string.py '${{ inputs.models-json }}'
         echo "##[set-output name=hash;]$hash"
@@ -255,6 +255,7 @@ runs:
       shell: powershell
       run: |
         Set-Location ${{ env.GITHUB_ACTION_PATH }}
+        conda activate comfyui
         python download-models.py raw "${{ inputs.models-json }}" "${{ env.GITHUB_WORKSPACE }}\models\"
 
     - name: '[Win] Run Python application'
@@ -271,6 +272,7 @@ runs:
       if: ${{ inputs.os == 'windows' }}
       run: |
         cd $Env:GITHUB_ACTION_PATH
+        conda activate comfyui
         python poll_server_start.py
       shell: powershell
 
@@ -292,6 +294,7 @@ runs:
       shell: powershell
       run: |
         Set-Location ${{ env.GITHUB_ACTION_PATH }}
+        conda activate comfyui
         Write-Host "Running workflows: ${{ inputs.workflow_filenames }}"
         python queue_prompt.py `
           --comfy-workflow-names "${{ inputs.workflow_filenames }}" `

--- a/action.yml
+++ b/action.yml
@@ -226,6 +226,7 @@ runs:
       with:
         activate-environment: comfyui
         auto-activate-base: false
+        miniconda-version: "latest"
         environment-file: ${{ inputs.conda_env_file }}
         use-only-tar-bz2: true
 

--- a/action.yml
+++ b/action.yml
@@ -263,9 +263,10 @@ runs:
         ls
         conda activate comfyui
         $jsonInput = '${{ inputs.models-json }}'
+        $jsonInputEscaped = $jsonInput -replace '"', '\"'
         $outputDir = "$Env:GITHUB_WORKSPACE\models\"
-        Write-Host "Running download-models.py with input: $jsonInput and output directory: $outputDir"
-        python download-models.py raw "$jsonInput" "$outputDir"
+        Write-Host "Running download-models.py with input: $jsonInputEscaped and output directory: $outputDir"
+        python download-models.py raw "$jsonInputEscaped" "$outputDir"
 
     - name: '[Win] Run Python application'
       if: ${{ inputs.os == 'windows' }}

--- a/action.yml
+++ b/action.yml
@@ -215,6 +215,7 @@ runs:
       shell: powershell
       run: |
         conda env create -f ${{ inputs.conda_env_file }}
+        conda activate comfyui
 
     - name: "[Win] Check conda environment"
       if: ${{ inputs.os == 'windows' }}
@@ -228,7 +229,7 @@ runs:
       id: generate_hash_windows
       run: |
         Set-Location ${{ env.GITHUB_ACTION_PATH }}
-        $hash = python hash_string.py '${{ inputs.models-json }}'
+        $hash = python3 hash_string.py '${{ inputs.models-json }}'
         echo "##[set-output name=hash;]$hash"
       shell: powershell
 

--- a/action.yml
+++ b/action.yml
@@ -226,8 +226,7 @@ runs:
       with:
         activate-environment: comfyui
         auto-activate-base: false
-        auto-update-conda: true
-        miniconda-version: latest
+        auto-update-conda: false
         environment-file: ${{ inputs.conda_env_file }}
         use-only-tar-bz2: true
 

--- a/action.yml
+++ b/action.yml
@@ -225,10 +225,9 @@ runs:
       if: ${{ inputs.os == 'windows' }}
       with:
         auto-update-conda: true
-        miniconda-version: latest
+        miniconda-version: "latest"
         activate-environment: comfyui
         auto-activate-base: false
-        environment-file: ${{ inputs.conda_env_file }}
         use-only-tar-bz2: true
       continue-on-error: true
 
@@ -242,12 +241,7 @@ runs:
     - name: Generate hash from models-json
       if: ${{ inputs.os == 'windows' }}
       id: generate_hash_windows
-      run: |
-        $jsonString = @'${{ inputs.models-json }}'@
-        $bytes = [System.Text.Encoding]::UTF8.GetBytes($jsonString)
-        $stream = [System.IO.MemoryStream]::new($bytes)
-        $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stream).Hash
-        echo "hash=$hash" >> $env:GITHUB_OUTPUT
+      run: python hash_string.py '${{ inputs.models-json }}'
       shell: powershell
 
 

--- a/action.yml
+++ b/action.yml
@@ -228,10 +228,12 @@ runs:
       if: ${{ inputs.os == 'windows' }}
       id: generate_hash_windows
       run: |
+        Set-Location $Env:GITHUB_ACTION_PATH
         conda activate comfyui
-        Set-Location ${{ env.GITHUB_ACTION_PATH }}
-        $hash = python hash_string.py '${{ inputs.models-json }}'
-        echo "##[set-output name=hash;]$hash"
+        ls
+        python hash_string.py '${{ inputs.models-json }}' > hash_output.txt
+        $hash = Get-Content hash_output.txt
+        echo "hash=$hash" >> $Env:GITHUB_ENV
       shell: powershell
 
 
@@ -256,6 +258,7 @@ runs:
       shell: powershell
       run: |
         Set-Location ${{ env.GITHUB_ACTION_PATH }}
+        ls
         conda activate comfyui
         python download-models.py raw "${{ inputs.models-json }}" "${{ env.GITHUB_WORKSPACE }}\models\"
 

--- a/action.yml
+++ b/action.yml
@@ -224,10 +224,10 @@ runs:
       uses: conda-incubator/setup-miniconda@v3
       if: ${{ inputs.os == 'windows' }}
       with:
-        auto-update-conda: true
-        miniconda-version: "latest"
+        auto-update-conda: false
         activate-environment: comfyui
         auto-activate-base: false
+        environment-file: ${{ inputs.conda_env_file }}
         use-only-tar-bz2: true
       continue-on-error: true
 

--- a/action.yml
+++ b/action.yml
@@ -172,8 +172,8 @@ runs:
         python3 queue_prompt.py --comfy-workflow-names ${{ inputs.workflow_filenames }} --github-action-workflow-name "${{ github.workflow }}" --os "${{ inputs.os }}" --run-id "${{ github.run_id }}" --gsc-bucket-name "${{ inputs.gcs_bucket_name }}" --workspace-path "${{ github.workspace }}" --output-file-prefix ${{ inputs.output_prefix }} --repo "${{ github.repository }}" --commit-hash "${{ steps.unix_get_commit_details.outputs.commit_hash }}" --commit-time "${{ steps.unix_get_commit_details.outputs.commit_time }}" --commit-message "${{ steps.unix_get_commit_details.outputs.commit_title }}" --branch-name "${{ github.ref_name }}" --api-endpoint "${{ inputs.api_endpoint }}" 
 
     - name: '[Unix] Upload log file'
+      if: ${{ inputs.os != 'windows' }}
       uses: actions/upload-artifact@v4
-      if: ${{ success() || failure() }}
       with:
         name: app-logs-${{ github.job }}-${{ inputs.os }}-${{inputs.workflow_name}}-${{ github.run_id }}
         path: ${{ github.workspace }}/application.log

--- a/action.yml
+++ b/action.yml
@@ -347,3 +347,8 @@ runs:
       with:
         name: app-logs-${{ github.job }}-${{ inputs.os }}-${{inputs.workflow_name}}-${{ github.run_id }}
         path: ${{ github.workspace }}/application.log
+    
+    - name: '[Win] Cleanup output files only'
+      if: ${{ inputs.os == 'windows' && ( success() || failure() ) }}
+      shell: powershell
+      run: Remove-Item -Path "${{ github.workspace }}/output/*" -Recurse -Force

--- a/action.yml
+++ b/action.yml
@@ -226,7 +226,8 @@ runs:
       with:
         activate-environment: comfyui
         auto-activate-base: false
-        miniconda-version: "latest"
+        auto-update-conda: true
+        miniconda-version: latest
         environment-file: ${{ inputs.conda_env_file }}
         use-only-tar-bz2: true
 

--- a/action.yml
+++ b/action.yml
@@ -236,7 +236,13 @@ runs:
         conda list
       shell: powershell
 
-    
+    - name: Generate hash from models-json
+      id: generate_hash_windows
+      run: |
+        $hash = (Get-FileHash -Algorithm SHA256 -InputStream ([System.IO.MemoryStream][System.Text.Encoding]::UTF8.GetBytes("${{ inputs.models-json }}"))).Hash
+        echo "::set-output name=hash::$hash"
+      shell: powershell
+  
 
     # Keep in mind the self runner must be setup with a model in C:\actions-runner\
     - name: '[Win] Download models'

--- a/action.yml
+++ b/action.yml
@@ -214,7 +214,7 @@ runs:
       if: ${{ inputs.os == 'windows' }}
       shell: powershell
       run: |
-        conda env create -f ${{ inputs.conda_env_file }}
+        conda env update -f ${{ inputs.conda_env_file }}
 
     - name: "[Win] Check conda environment"
       if: ${{ inputs.os == 'windows' }}

--- a/action.yml
+++ b/action.yml
@@ -126,6 +126,7 @@ runs:
       with:
         path: ${{ github.workspace }}/models
         key: ${{ runner.os }}-models-${{ steps.generate_hash.outputs.hash }}
+        save-always: true
   
     - name: '[Unix] Download models'
       if: ${{ inputs.os != 'windows' }}
@@ -245,6 +246,7 @@ runs:
       with:
         path: ${{ github.workspace }}/models
         key: ${{ runner.os }}-models-${{ steps.generate_hash_windows.outputs.hash }}
+        save-always: true
 
     # Keep in mind the self runner must be setup with a model in C:\actions-runner\
     # - name: '[Win] Download models'
@@ -303,7 +305,7 @@ runs:
       if: ${{ inputs.os == 'windows' }}
       shell: powershell
       run: |
-        Set-Location ${{ env.GITHUB_ACTION_PATH }}
+        cd $Env:GITHUB_ACTION_PATH
         conda activate comfyui
         Write-Host "Running workflows: ${{ inputs.workflow_filenames }}"
         python queue_prompt.py `

--- a/action.yml
+++ b/action.yml
@@ -227,7 +227,7 @@ runs:
         activate-environment: comfyui
         auto-activate-base: false
         auto-update-conda: true
-        miniconda-version: "py312_24.4.0-0"
+        miniconda-version: latest
         environment-file: ${{ inputs.conda_env_file }}
         use-only-tar-bz2: true
 

--- a/action.yml
+++ b/action.yml
@@ -224,11 +224,13 @@ runs:
       uses: conda-incubator/setup-miniconda@v3
       if: ${{ inputs.os == 'windows' }}
       with:
+        auto-update-conda: true
+        miniconda-version: latest
         activate-environment: comfyui
         auto-activate-base: false
-        auto-update-conda: false
         environment-file: ${{ inputs.conda_env_file }}
         use-only-tar-bz2: true
+      continue-on-error: true
 
     - name: "[Win] Check conda environment"
       if: ${{ inputs.os == 'windows' }}

--- a/action.yml
+++ b/action.yml
@@ -219,6 +219,7 @@ runs:
     - name: "[Win] Check conda environment"
       if: ${{ inputs.os == 'windows' }}
       run: |
+        conda activate comfyui
         conda info
         conda list
       shell: powershell
@@ -229,7 +230,7 @@ runs:
       run: |
         conda activate comfyui
         Set-Location ${{ env.GITHUB_ACTION_PATH }}
-        $hash = python3 hash_string.py '${{ inputs.models-json }}'
+        $hash = python hash_string.py '${{ inputs.models-json }}'
         echo "##[set-output name=hash;]$hash"
       shell: powershell
 

--- a/action.yml
+++ b/action.yml
@@ -227,7 +227,7 @@ runs:
         activate-environment: comfyui
         auto-activate-base: false
         auto-update-conda: true
-        miniconda-version: latest
+        miniconda-version: 24.5.0
         environment-file: ${{ inputs.conda_env_file }}
         use-only-tar-bz2: true
 

--- a/action.yml
+++ b/action.yml
@@ -243,22 +243,13 @@ runs:
       if: ${{ inputs.os == 'windows' }}
       id: generate_hash_windows
       run: |
-        # Escape the JSON string from the GitHub Actions input
-        $jsonString = "${{ inputs.models-json }}"
-        $jsonString = $jsonString -replace '"', '\"'
-        
-        # Convert the JSON string to bytes
+        $jsonString = @'${{ inputs.models-json }}'@
         $bytes = [System.Text.Encoding]::UTF8.GetBytes($jsonString)
-        
-        # Create a memory stream from the bytes
         $stream = [System.IO.MemoryStream]::new($bytes)
-        
-        # Calculate the SHA256 hash of the data in the memory stream
         $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stream).Hash
-        
-        # Output the hash to the GitHub Actions environment
-        echo "hash=$hash" >> $GITHUB_OUTPUT
+        echo "hash=$hash" >> $env:GITHUB_OUTPUT
       shell: powershell
+
 
     - name: '[Windows] Cache models'
       if: ${{ inputs.os == 'windows' }}

--- a/action.yml
+++ b/action.yml
@@ -227,7 +227,7 @@ runs:
         activate-environment: comfyui
         auto-activate-base: false
         auto-update-conda: true
-        miniconda-version: 24.5.0
+        miniconda-version: "Miniconda3-py312_24.4.0-0-Windows-x86_64.exe"
         environment-file: ${{ inputs.conda_env_file }}
         use-only-tar-bz2: true
 

--- a/action.yml
+++ b/action.yml
@@ -243,10 +243,20 @@ runs:
       if: ${{ inputs.os == 'windows' }}
       id: generate_hash_windows
       run: |
-        $jsonString = '{"v1-5-pruned-emaonly.ckpt": {"url": "https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.ckpt", "directory": "checkpoints"}}'
+        # Escape the JSON string from the GitHub Actions input
+        $jsonString = "${{ inputs.models-json }}"
+        $jsonString = $jsonString -replace '"', '\"'
+        
+        # Convert the JSON string to bytes
         $bytes = [System.Text.Encoding]::UTF8.GetBytes($jsonString)
+        
+        # Create a memory stream from the bytes
         $stream = [System.IO.MemoryStream]::new($bytes)
+        
+        # Calculate the SHA256 hash of the data in the memory stream
         $hash = (Get-FileHash -Algorithm SHA256 -InputStream $stream).Hash
+        
+        # Output the hash to the GitHub Actions environment
         echo "hash=$hash" >> $GITHUB_OUTPUT
       shell: powershell
 

--- a/action.yml
+++ b/action.yml
@@ -241,7 +241,10 @@ runs:
     - name: Generate hash from models-json
       if: ${{ inputs.os == 'windows' }}
       id: generate_hash_windows
-      run: python hash_string.py '${{ inputs.models-json }}'
+      run: |
+        Set-Location ${{ env.GITHUB_ACTION_PATH }}
+        $hash = python hash_string.py '${{ inputs.models-json }}'
+        echo "##[set-output name=hash;]$hash"
       shell: powershell
 
 

--- a/action.yml
+++ b/action.yml
@@ -87,10 +87,11 @@ runs:
       with:
         credentials_json: "${{ inputs.google_credentials }}"
   
-    - name: Cache conda
+    - name: '[Unix] Cache Conda'
+      if: ${{ inputs.os != 'windows' }}
       uses: actions/cache@v4
       env:
-          # Increase this value to reset cache if etc/environment.yml has not changed
+          # Increase this value to reset cache if the environment file has not changed
           CACHE_NUMBER: 0
       with:
         path: ~/miniconda3/envs/comfyui
@@ -209,21 +210,24 @@ runs:
     ##                                                                                 ##
     #####################################################################################
 
+    - name: '[Windows] Cache Conda'
+      if: ${{ inputs.os != 'windows' }}
+      uses: actions/cache@v4
+      env:
+          # Increase this value to reset cache if the environment file has not changed
+          CACHE_NUMBER: 0
+      with:
+        path: C:\Miniconda3\envs\comfyui
+        key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles(format('{0}', inputs.conda_env_file)) }}
+
     - name: '[Win] Setup Conda'
       uses: conda-incubator/setup-miniconda@v3.0.3
       if: ${{ inputs.os == 'windows' }}
       with:
-        auto-update-conda: true
-        miniconda-version: latest
         activate-environment: comfyui
-        python-version: ${{ inputs.python_version }}
-      continue-on-error: true
-
-    - name: '[Win-Only] Install Pytorch'
-      if: ${{ inputs.os == 'windows' }}
-      shell: powershell
-      run: |
-        conda install pytorch torchvision torchaudio pytorch-cuda=${{ inputs.cuda_version }} -c pytorch -c nvidia --yes
+        auto-activate-base: false
+        environment-file: ${{ inputs.conda_env_file }}
+        use-only-tar-bz2: true
 
     - name: "[Win] Check conda environment"
       if: ${{ inputs.os == 'windows' }}
@@ -232,12 +236,7 @@ runs:
         conda list
       shell: powershell
 
-    - name: '[Win] Install dependencies'
-      if: ${{ inputs.os == 'windows' }}
-      shell: powershell
-      run: |
-        Get-Command pip
-        pip install -r requirements.txt
+    
 
     # Keep in mind the self runner must be setup with a model in C:\actions-runner\
     - name: '[Win] Download models'

--- a/hash_string.py
+++ b/hash_string.py
@@ -1,0 +1,31 @@
+import hashlib
+import sys
+import json
+
+
+def main(json_string):
+    # Ensure the JSON string is valid
+    try:
+        json_data = json.loads(json_string)
+    except json.JSONDecodeError:
+        print("Invalid JSON string")
+        sys.exit(1)
+
+    # Convert JSON string to bytes
+    json_bytes = json_string.encode("utf-8")
+
+    # Calculate SHA256 hash
+    hash_object = hashlib.sha256(json_bytes)
+    hash_hex = hash_object.hexdigest()
+
+    # Output the hash
+    print(f"hash={hash_hex}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python generate_hash.py '<json_string>'")
+        sys.exit(1)
+
+    json_string = sys.argv[1]
+    main(json_string)

--- a/hash_string.py
+++ b/hash_string.py
@@ -4,13 +4,6 @@ import json
 
 
 def main(json_string):
-    # Ensure the JSON string is valid
-    try:
-        json_data = json.loads(json_string)
-    except json.JSONDecodeError:
-        print("Invalid JSON string")
-        sys.exit(1)
-
     # Convert JSON string to bytes
     json_bytes = json_string.encode("utf-8")
 

--- a/hash_string.py
+++ b/hash_string.py
@@ -19,7 +19,7 @@ def main(json_string):
     hash_hex = hash_object.hexdigest()
 
     # Output the hash
-    print(f"hash={hash_hex}")
+    print(hash_hex)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Get rid of setup-miniconda GH. Manually set up miniconda on machine once and that step is skipped in later runs.
- Cache models 